### PR TITLE
Troca deploy contínuo para ser realizado a partir da branch dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ name: "pre-release"
 on:
   # Triggers the workflow on push or pull request events but only for the dev branch
   push:
-    branches: [ main ]
+    branches: [ dev ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Descrição 

O presente PR troca a GitHub Action de deploy contínuo de homologação para realizar lançamentos a partir da branch dev.

## Tarefas realizadas

- [x] Troca deploy contínuo para ser realizado a partir da branch dev.
