### PR TITLE
Add GH Action to upload coverage report

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,24 @@
+name: Jest tests pipeline
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the dev branch
+  push:
+    branches: [ dev ]
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install modules and run tests
+        run: |
+          cd projeto-kokama
+          yarn
+          yarn test
+      - name: Publish tests to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          files: ./projeto-kokama/coverage/coverage-final.json
+          flags: unittests
+          fail_ci_if_error: true
+          verbose: false

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,4 @@
-name: Jest tests pipeline
+name: Publish tests
 # Controls when the action will run. 
 on:
   # Triggers the workflow on push or pull request events but only for the dev branch

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2020.2-Projeto-Kokama-Front-end&metric=alert_status)](https://sonarcloud.io/dashboard?id=fga-eps-mds_2020.2-Projeto-Kokama-Front-end)
+[![codecov](https://codecov.io/gh/fga-eps-mds/2020.2-Projeto-Kokama-Front-end/branch/dev/graph/badge.svg?token=Q1MXF6Z70S)](https://codecov.io/gh/fga-eps-mds/2020.2-Projeto-Kokama-Front-end)
 
 # 2020.2-Projeto-Kokama-Front-end
 


### PR DESCRIPTION
## Descrição 

Criação do scritp de verificação dos testes para incluir upload para o Code Climate, gerando a badge de cobertura.

**Resolve parcialmente a issue [#186](https://github.com/fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/186).**

## Tarefas realizadas

- [x] Realizar upload do arquivo de report ao Codecov;
- [x] Apresentar a badge de cobertura.